### PR TITLE
fix: resolve horizontal overflow on mobile marketing page

### DIFF
--- a/vivahgo/src/marketing-home.css
+++ b/vivahgo/src/marketing-home.css
@@ -3400,6 +3400,7 @@ body[data-route='home'] #root {
 
   .marketing-home-shell {
     padding-bottom: 40px;
+    overflow-x: hidden;
   }
 
   .marketing-budget-cost-table,


### PR DESCRIPTION
## What
Fixed horizontal overflow on mobile marketing page

## Why
Users could scroll horizontally on mobile which is unintended and affects UX

## How
Added overflow-x: hidden to .marketing-home-shell inside mobile media query (max-width: 720px)